### PR TITLE
Updated Huboard Labels to display active issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ Test Git Repository
 And an edit!
 
 [![Issues](https://img.shields.io/github/issues/Seahermit/Test.svg?label=HuBoard)](https://huboard.com/Seahermit/Test)
-[![Next release](https://img.shields.io/github/issues-raw/Seahermit/Test/1%20-%20Next release.svg?label=Next%20Release)](https://huboard.com/Seahermit/Test)
-[![Working     ](https://img.shields.io/github/issues-raw/Seahermit/Test/2%20-%20Working%20%3c%3d%207.svg?label=Working)](https://huboard.com/Seahermit/Test)
-[![In Review   ](https://img.shields.io/github/issues-raw/Seahermit/Test/3%20-%20In%20Review.svg?label=In%20Review)](https://huboard.com/Seahermit/Test)
+[![Next](https://img.shields.io/github/issues-raw/Seahermit/Test/1%20-%20Next.svg?label=Next)](https://huboard.com/Seahermit/Test)
+[![Working](https://img.shields.io/github/issues-raw/Seahermit/Test/2%20-%20Working%20%3c%3d%2011.svg?label=Working)](https://huboard.com/Seahermit/Test)
+[![Review](https://img.shields.io/github/issues-raw/Seahermit/Test/3%20-%20Review.svg?label=Review)](https://huboard.com/Seahermit/Test)


### PR DESCRIPTION
Need the img.shields.io link to include the label name, including spaces (as %20) and <= whatever...

e.g.

[![Working](https://img.shields.io/github/issues-raw/Seahermit/Test/2%20-%20Working%20%3c%3d%2011.svg?label=Working)](https://huboard.com/Seahermit/Test)